### PR TITLE
Added default celo configuration for grunt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/goerli/netstats-server /netstats-server
 WORKDIR /netstats-server
 RUN npm install
 RUN npm install -g grunt-cli
-RUN grunt
+RUN grunt --configPath="src/js/celoConfig.js"
 
 EXPOSE  3000
 CMD ["npm", "start"]

--- a/src/js/celoConfig.js
+++ b/src/js/celoConfig.js
@@ -1,0 +1,2 @@
+var networkName = 'Celo';
+var faviconPath = '/favicon.ico';


### PR DESCRIPTION
Added a default configuration for Ethstats title in Celo Networks. The Ethstats title will be _Celo_.

Probably we should address sometime to get the network name from some configurable way during execution time (i.e.: config file or env variable).  