### PR TITLE
WIP account for validatorSigners in auth and search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ADD . /celostats-server
 WORKDIR /celostats-server
 RUN npm install
 RUN npm install -g grunt-cli
+RUN sed -i "s#networkName =.*#networkName = '${NETWORK_NAME:-Celo}'#g" src/js/celoConfig.js
+RUN sed -i "s#blockscoutUrl =.*#blockscoutUrl = '${BLOCKSOUT_URL:-https://baklava-blockscout.celo-testnet.org/}'#g" src/js/celoConfig.js
 RUN grunt --configPath="src/js/celoConfig.js"
 
 EXPOSE  3000

--- a/app.js
+++ b/app.js
@@ -188,10 +188,12 @@ api.on('connection', function (spark) {
         stats.block.validators.registered.forEach(validator => {
           validator.registered = true
           // trust registered validators and signers - not safe
-          if (validator.signer.address && ~trusted.indexOf(validator.address))
+          if (validator.address && trusted.indexOf(validator.address) === -1) {
             trusted.push(validator.address)
-          if (validator.signer && ~trusted.indexOf(validator.signer))
-            trusted.push(validator.signer.address)
+          }
+          if (validator.signer && trusted.indexOf(validator.signer) === -1) {
+            trusted.push(validator.signer)
+          }
           const search = { id: validator.address }
           const index = Nodes.getIndex(search)
           const node = Nodes.getNodeOrNew(search, validator)

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -25,12 +25,12 @@ Collection.prototype.setupSockets = function () {
 }
 
 Collection.prototype.add = function (data, callback) {
-  var node = this.getNodeOrNew({ id: data.id }, data);
+  const node = this.getNodeOrNew({validatorData: {signer: data.id}}, data);
   node.setInfo(data, callback);
 }
 
 Collection.prototype.update = function (id, stats, callback) {
-  var node = this.getNode({ id: id });
+  var node = this.getNode({validatorData: {signer: id}});
 
   if (!node) {
     callback('Node not found', null);
@@ -54,10 +54,11 @@ Collection.prototype.update = function (id, stats, callback) {
 }
 
 Collection.prototype.addBlock = function (id, stats, callback) {
-  var node = this.getNode({ id: id });
+  const node = this.getNode({validatorData: {signer: id}});
 
   if (!node) {
-    callback('Node not found', null);
+    console.error(this._items.map(item=> console.log(item.validatorData.signer)))
+    callback(`Node ${id} not found`, null);
   } else {
     // this._blockchain.clean(this.getBestBlockFromItems());
 
@@ -87,7 +88,7 @@ Collection.prototype.addBlock = function (id, stats, callback) {
 }
 
 Collection.prototype.updatePending = function (id, stats, callback) {
-  var node = this.getNode({ id: id });
+  var node = this.getNode({validatorData: {signer: id}});
 
   if (!node)
     return false;
@@ -96,7 +97,7 @@ Collection.prototype.updatePending = function (id, stats, callback) {
 }
 
 Collection.prototype.updateStats = function (id, stats, callback) {
-  var node = this.getNode({ id: id });
+  var node = this.getNode({validatorData: {signer: id}});
 
   if (!node) {
     callback('Node not found', null);
@@ -107,7 +108,7 @@ Collection.prototype.updateStats = function (id, stats, callback) {
 
 // TODO: Async series
 Collection.prototype.addHistory = function (id, blocks, callback) {
-  var node = this.getNode({ id: id });
+  var node = this.getNode({validatorData: {signer: id}});
 
   if (!node) {
     callback('Node not found', null)
@@ -127,7 +128,7 @@ Collection.prototype.addHistory = function (id, blocks, callback) {
 }
 
 Collection.prototype.updateLatency = function (id, latency, callback) {
-  var node = this.getNode({ id: id });
+  var node = this.getNode({validatorData: {signer: id}});
 
   if (!node)
     return false;

--- a/lib/node.js
+++ b/lib/node.js
@@ -14,6 +14,7 @@ var Node = function (data) {
     affiliation: null,
     registered: false,
     elected: false,
+    signer: null
   }
   this.trusted = false;
   this.info = {};
@@ -103,7 +104,7 @@ Node.prototype.setInfo = function (data, callback) {
   this.spark = _.result(data, 'spark', null);
 
   this.setState(true);
-
+  this.validatorData.signer = this.id
   if (callback !== null) {
     callback(null, this.getInfo());
   }
@@ -113,6 +114,7 @@ Node.prototype.setValidatorData = function (data) {
   this.info.name = data.name || data.address
   this.info.contact = data.address
   this.trusted = true
+  this.validatorData.signer = data.signer
   this.id = data.address
   this.address = data.address
 }

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -2,6 +2,7 @@ var trusted = [
 	"0x47e172f6cfb6c7d01c1574fa3e2be7cc73269D95",
 	"0xa42c9b0d1a30722aea8b81e72957134897e7a11a",
 	"0xa0af2e71cecc248f4a7fd606f203467b500dd53b",
+	"0x7f586ca3e80f71097fc28a2ecfef92ac47fb2263"
 ]
 
 var banned = [];


### PR DESCRIPTION
Currently a node has only one fix address, the one of the validator.

Nodes can have a signer thats different for the validator. this needs to be accounted for.